### PR TITLE
Update config.json

### DIFF
--- a/qsusb/config.json
+++ b/qsusb/config.json
@@ -7,10 +7,7 @@
   "boot": "auto",
   "url": "https://github.com/nardusleroux/hassio-qsusb",
   "webui": "http://[HOST]:[PORT:2020]",
-  "devices": [
-    "/dev/bus/usb",
-    "/dev/bus/usb:rwm"
-  ],
+  "devices": ["/dev/bus/usb"],
   "arch": [
     "aarch64",
     "amd64",

--- a/qsusb/config.json
+++ b/qsusb/config.json
@@ -2,7 +2,7 @@
   "name": "QwikSwitch USB Hub",
   "slug": "qsusb",
   "description": "Add-on for the QwikSwitch USB Hub",
-  "version": "0.93",
+  "version": "0.94",
   "startup": "services",
   "boot": "auto",
   "url": "https://github.com/nardusleroux/hassio-qsusb",


### PR DESCRIPTION
Fix this warning:
[supervisor.addons.validate] Add-on config 'devices' use a deprecated format, the new format uses a list of paths only. Please report this to the maintainer of QwikSwitch USB Hub