### PR TITLE
Allow API call to /host/info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ The [qwikswitch component](https://www.home-assistant.io/components/qwikswitch/)
 
 ## Installation
 
-1. Add the repository through the HomeAssistant Supervisor `https://github.com/nardusleroux/hassio-qsusb`. (From the HomeAssistant frontend: *Supervisor* > *Add-on store* > *...* > *Repositories*)
+1. Add the repository to the HomeAssistant Supervisor
+   <br>[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fnardusleroux%2Fhassio-qsusb)
+   `https://github.com/nardusleroux/hassio-qsusb`. (From the HomeAssistant frontend: *Supervisor* > *Add-on store* > *...* > *Repositories*)
 2. Install the *QwikSwitch USB Hub* Addon
 3. Configure the Qwikswitch devices in the Config section.
 

--- a/qsusb/config.json
+++ b/qsusb/config.json
@@ -2,7 +2,7 @@
   "name": "QwikSwitch USB Hub",
   "slug": "qsusb",
   "description": "Add-on for the QwikSwitch USB Hub",
-  "version": "0.94",
+  "version": "0.95",
   "startup": "services",
   "boot": "auto",
   "url": "https://github.com/nardusleroux/hassio-qsusb",
@@ -22,6 +22,7 @@
   "ports_description": {
     "2020/tcp": "QS USB Web UI"
   },
+  "hassio_api": true,
   "hassio_role": "default",
   "host_network": true,
   "options": {


### PR DESCRIPTION
Update install doc & fix this error
```
21-09-01 19:46:33 WARNING (MainThread) [supervisor.api.middleware.security] 84bcc508_qsusb missing API permission for /host/info
21-09-01 19:46:33 ERROR (MainThread) [supervisor.api.middleware.security] Invalid token for access /host/info
```